### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     author="Álvaro Fernández Rojas",
     author_email="noltari@gmail.com",
     description="Library to control QNAP QSW devices",
+    license="ASL 2.0",
     long_description=README_FILE.read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     packages=["aioqsw"],


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.